### PR TITLE
Extension Chrome TTS : lecture du texte sélectionné en français

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,23 @@
-# AI
+# Extension Chrome : Lecture de sélection (FR)
+
+Cette extension lit **en français** le texte sélectionné dans l'onglet actif grâce à l'API `chrome.tts`.
+
+## Installation (mode développeur)
+
+1. Ouvrez `chrome://extensions`.
+2. Activez le mode développeur.
+3. Cliquez sur **Charger l'extension non empaquetée**.
+4. Sélectionnez ce dossier (`/workspace/AI`).
+
+## Utilisation
+
+1. Sur une page web, sélectionnez un texte.
+2. Cliquez sur l'icône de l'extension.
+3. Cliquez sur **🔊 Lire en français**.
+
+## Fichiers
+
+- `manifest.json` : déclaration de l'extension (Manifest V3).
+- `popup.html` : interface du popup.
+- `popup.css` : styles du popup.
+- `popup.js` : récupération de la sélection et lecture TTS en `fr-FR`.

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,11 @@
+{
+  "manifest_version": 3,
+  "name": "Lecture de sélection (FR)",
+  "version": "1.0.0",
+  "description": "Lit en français le texte sélectionné dans l'onglet actif.",
+  "permissions": ["activeTab", "scripting", "tts"],
+  "action": {
+    "default_title": "Lire la sélection",
+    "default_popup": "popup.html"
+  }
+}

--- a/popup.css
+++ b/popup.css
@@ -1,0 +1,33 @@
+:root {
+  color-scheme: light dark;
+  font-family: Arial, sans-serif;
+}
+
+body {
+  margin: 0;
+  min-width: 320px;
+}
+
+.container {
+  padding: 14px;
+}
+
+h1 {
+  font-size: 1rem;
+  margin: 0 0 10px;
+}
+
+.status {
+  min-height: 2.5em;
+  font-size: 0.9rem;
+  margin: 0 0 10px;
+}
+
+button {
+  width: 100%;
+  padding: 10px;
+  border: 0;
+  border-radius: 8px;
+  font-weight: bold;
+  cursor: pointer;
+}

--- a/popup.html
+++ b/popup.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html lang="fr">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Lecture de sélection</title>
+    <link rel="stylesheet" href="popup.css" />
+  </head>
+  <body>
+    <main class="container">
+      <h1>Lecture de sélection</h1>
+      <p id="status" class="status">Cliquez pour lire le texte sélectionné.</p>
+      <button id="readBtn" type="button">🔊 Lire en français</button>
+    </main>
+    <script src="popup.js"></script>
+  </body>
+</html>

--- a/popup.js
+++ b/popup.js
@@ -1,0 +1,52 @@
+const statusEl = document.getElementById('status');
+const readBtn = document.getElementById('readBtn');
+
+function setStatus(message, isError = false) {
+  statusEl.textContent = message;
+  statusEl.style.color = isError ? '#b00020' : '';
+}
+
+async function getSelectedText() {
+  const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
+
+  if (!tab || typeof tab.id !== 'number') {
+    throw new Error('Aucun onglet actif trouvé.');
+  }
+
+  const [{ result }] = await chrome.scripting.executeScript({
+    target: { tabId: tab.id },
+    func: () => window.getSelection()?.toString().trim() ?? ''
+  });
+
+  return result;
+}
+
+function speakFrench(text) {
+  chrome.tts.stop();
+
+  chrome.tts.speak(text, {
+    lang: 'fr-FR',
+    rate: 1,
+    pitch: 1,
+    volume: 1,
+    enqueue: false
+  });
+}
+
+readBtn.addEventListener('click', async () => {
+  setStatus('Recherche de texte sélectionné…');
+
+  try {
+    const selectedText = await getSelectedText();
+
+    if (!selectedText) {
+      setStatus('Sélectionnez un texte dans la page puis réessayez.', true);
+      return;
+    }
+
+    speakFrench(selectedText);
+    setStatus('Lecture en cours.');
+  } catch (error) {
+    setStatus(`Erreur : ${error.message}`, true);
+  }
+});


### PR DESCRIPTION
### Motivation
- Permettre à l'utilisateur de faire lire en français le texte sélectionné dans l'onglet actif via une extension Chrome simple.

### Description
- Ajout de `manifest.json` (Manifest V3) déclarant les permissions `activeTab`, `scripting` et `tts` et un `default_popup` pointant vers `popup.html`.
- Ajout de l'interface `popup.html` et du style `popup.css` offrant un bouton «🔊 Lire en français» et une zone de statut utilisateur.
- Implémentation de la logique dans `popup.js` qui récupère la sélection avec `chrome.scripting.executeScript` et joue le texte avec `chrome.tts.speak(..., { lang: 'fr-FR' })` en gérant les erreurs et l'absence de sélection.
- Mise à jour du `README.md` avec les instructions d'installation en mode développeur et d'utilisation.

### Testing
- Validation JSON du manifeste avec `python -m json.tool manifest.json` a réussi.
- Vérification de la syntaxe JavaScript avec `node --check popup.js` a réussi.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69eb1ba5bd3c8324b8671e7bd5afa389)